### PR TITLE
Update ClodeSlide to allow user to override props

### DIFF
--- a/src/CodeSlide.js
+++ b/src/CodeSlide.js
@@ -133,7 +133,7 @@ class CodeSlide extends React.Component {
     });
 
     return (
-      <Slide {...rest} bgColor="#122b45" margin={1}>
+      <Slide bgColor="#122b45" margin={1} {...rest}>
         {range.title && <CodeSlideTitle>{range.title}</CodeSlideTitle>}
 
         <pre ref="container" style={style}>


### PR DESCRIPTION
Moving the props spread to last allows the user to override the bgColor and other props of the nested <Slide/>
