### PR TITLE
Removed check that caused an exception because this.props.route is undefined

### DIFF
--- a/src/CodeSlide.js
+++ b/src/CodeSlide.js
@@ -105,10 +105,6 @@ class CodeSlide extends React.Component {
   };
 
   onKeyDown = e => {
-    if (this.props.slideIndex !== parseInt(this.props.route.slide)) {
-      return;
-    }
-
     let prev = this.state.active;
     let active = null;
 


### PR DESCRIPTION
When using spectacle-code-slide with spectacle 1.0.7 I consistently got an error from this line of code.

As far as I can tell from running the debugger on my presentation this onKeyDown function only runs when the user is on the correct slideIndex, and running CodeSlide without this check works just fine.

So I'm guessing something has changed in spectacle from a previous version unless I missed some use case. 
