### PR TITLE
Fix end line index

### DIFF
--- a/src/CodeSlide.js
+++ b/src/CodeSlide.js
@@ -16,7 +16,7 @@ const getComputedCodeStyle = require('./getComputedCodeStyle');
 function startOrEnd(index, loc) {
   if (index === loc[0]) {
     return 'start';
-  } else if (index - 1 === loc[1]) {
+  } else if (index === loc[1]) {
     return 'end';
   } else {
     return null;


### PR DESCRIPTION
From the docs `loc` starts from zero se there is no need to decrement the index by 1 when checking if it's the end of the range. 
This problem caused code not to be centered, as shown in the following screenshots, when `loc[1]` was the last line of the source code.
## Before

![before](https://cloud.githubusercontent.com/assets/10067273/18558690/4c7db27e-7b74-11e6-9599-4eda71df1d42.png)
## After removing `- 1`

![after](https://cloud.githubusercontent.com/assets/10067273/18558692/5150c070-7b74-11e6-8b47-00048453eb37.png)
