### PR TITLE
call ReactTransitionGroup hooks of Slide from CodeSlide

### DIFF
--- a/src/CodeSlide.js
+++ b/src/CodeSlide.js
@@ -88,6 +88,18 @@ class CodeSlide extends React.Component {
     window.removeEventListener('resize', this.onResize);
   }
 
+  componentWillEnter(cb) {
+    this.refs.slide.componentWillEnter(cb)
+  }
+
+  componentWillAppear(cb) {
+    this.refs.slide.componentWillAppear(cb)
+  }
+
+  componentWillLeave(cb) {
+    this.refs.slide.componentWillLeave(cb)
+  }
+
   getStorageId() {
     return 'code-slide:' + this.props.slideIndex;
   }
@@ -189,7 +201,7 @@ class CodeSlide extends React.Component {
     });
 
     return (
-      <Slide bgColor={slideBg} margin={1} {...rest}>
+      <Slide ref='slide' bgColor={slideBg} margin={1} {...rest}>
         {range.title && <CodeSlideTitle>{range.title}</CodeSlideTitle>}
 
         <pre ref="container" style={style}>


### PR DESCRIPTION
Hi,
I recently created slides using CodeSlide and it's very cool, thanks !

But I noticed that transitions doesn't work at all (I mean, spectacle Slide Transition).

It's because Spectacle use ReactTransitionGroup, and lifecycle hooks of this addons aren't called on the Slide component wrapped in the CodeSlide component, because it is wrapped.

ReactTransitionGroup lifecycle hooks are already automatically called on the CodeSlide component. This PR just call the hooks (`componentWillEnter`, `componentWillAppear`, `componentWillLeave`) of the Slide created by CodeSlide.
