### PR TITLE
Update documentation for spectacle 1.2.5 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export default class Presentation extends React.Component {
           <CodeSlide
             transition={[]}
             lang="js"
-            code={require("raw!../assets/code.example")}
+            code={require("raw-loader!../assets/code.example")}
             ranges={[
               { loc: [0, 270], title: "Walking through some code" },
               { loc: [0, 1], title: "The Beginning" },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "babel-preset-stage-1": "^6.11.4",
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
-    "spectacle": "^1.2.0"
+    "spectacle": "^1.2.5"
   }
 }


### PR DESCRIPTION
Update documentation for spectacle 1.2.5 using 'raw-loader' instead of 'raw' and update spectacle dev depedencies. Because spectacle now using webpack 2.0