### PR TITLE
Add 3 remaining transitionable methods to CodeSlide component

### DIFF
--- a/src/CodeSlide.js
+++ b/src/CodeSlide.js
@@ -100,6 +100,18 @@ class CodeSlide extends React.Component {
     this.refs.slide.componentWillLeave(cb)
   }
 
+  routerCallback(cb) {
+    this.refs.slide.routerCallback(cb)
+  }
+
+  transitionDirection(cb) {
+    this.refs.slide.transitionDirection(cb)
+  }
+
+  getTransitionStyles(cb) {
+    this.refs.slide.getTransitionStyles(cb)
+  }
+
   getStorageId() {
     return 'code-slide:' + this.props.slideIndex;
   }


### PR DESCRIPTION
Currently when adding `<CodeSlide>` to a `<Deck>` with transitions, it's janky... (as of spectacle 2.x, but looks to go back a ways).

It's because the Slide styles never update resulting in a permanent `transform: translate3d(-100%, 0px, 0px);`

This PR just adds the extra transitionable methods that are currently missing: https://github.com/FormidableLabs/spectacle/blob/master/src/components/transitionable.js#L28-L71
