### PR TITLE
Add localStorage prop

### DIFF
--- a/src/CodeSlide.js
+++ b/src/CodeSlide.js
@@ -56,7 +56,8 @@ class CodeSlide extends React.Component {
       title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
       note: PropTypes.oneOfType([PropTypes.element, PropTypes.string])
     })),
-    showLineNumbers: PropTypes.bool
+    showLineNumbers: PropTypes.bool,
+    localStorage: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -110,10 +111,12 @@ class CodeSlide extends React.Component {
   }
 
   getStorageItem() {
+    if (this.props.localStorage === false) return;
     return +localStorage.getItem(this.getStorageId());
   }
 
   setStorageItem(value) {
+    if (this.props.localStorage === false) return;
     return localStorage.setItem(this.getStorageId(), '' + value);
   }
 


### PR DESCRIPTION
I've found myself going on stage, starting my presentation in front of my crowd and all of my code slides being at the wrong location because their state was stored to `localStorage`.

I can't think of a reason I'd want to keep the state of the slides between practice runs and the real deal, so I've added a prop to disable that behaviour. (`localStorage`, with the default being the current behaviour)