### PR TITLE
fixes the zIndex of the code slide title

### DIFF
--- a/src/CodeSlideTitle.js
+++ b/src/CodeSlideTitle.js
@@ -10,7 +10,9 @@ const styles = {
   fontSize: '2.5em',
   color: 'white',
   // textTransform: 'uppercase',
-  whiteSpace: 'nowrap'
+  whiteSpace: 'nowrap',
+  zIndex: 1,
+  backgroundColor: 'rgba(0,0,0,0.5)'
 };
 
 class CodeSlideTitle extends React.Component {


### PR DESCRIPTION
on longer code snippets it can happen that the code slides above the title. This fix just sets a positive z-index and darkens the background to enhance readability.

before:
<img width="1216" alt="bildschirmfoto 2017-06-18 um 20 29 34" src="https://user-images.githubusercontent.com/3505939/27263253-e027d4bc-5465-11e7-87a0-f480bda00cae.png">

after:
<img width="1242" alt="bildschirmfoto 2017-06-18 um 20 30 08" src="https://user-images.githubusercontent.com/3505939/27263254-e19c9b7a-5465-11e7-92e6-fcb57be5f20c.png">

 

