### PR TITLE
Add spectacle v2 as a valid peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
-    "spectacle": "^1.0.4"
+    "spectacle": "^1.0.4 || ^2"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
i've been using code-slide with spectacle v2 w/o issues, so it seems valid to accept it in the peer dependency definition. 

this allows `npm ls` to exit with a zero exit-code when used with v2, which i like to run as part of my build to better ensure my dependencies are compatible.