### PR TITLE
Migrate to use prop-types for React 16+ usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "component-tween": "^1.2.0",
     "lodash.clamp": "^4.0.1",
     "lodash.memoize": "^4.0.1",
-    "lodash.padstart": "^4.2.0"
+    "lodash.padstart": "^4.2.0",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",

--- a/src/CodeSlide.js
+++ b/src/CodeSlide.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const {PropTypes} = React;
+const PropTypes = require('prop-types');
 
 const {Slide} = require('spectacle');
 const CodeSlideTitle = require('./CodeSlideTitle');
@@ -64,8 +64,8 @@ class CodeSlide extends React.Component {
   };
 
   static contextTypes = {
-    store: React.PropTypes.object.isRequired,
-    updateNotes: React.PropTypes.func
+    store: PropTypes.object.isRequired,
+    updateNotes: PropTypes.func
   };
 
   state = {


### PR DESCRIPTION
React has split PropTypes into it's own package.
https://reactjs.org/docs/typechecking-with-proptypes.html