### PR TITLE
Do not mutate style object in render

### DIFF
--- a/src/CodeSlide.js
+++ b/src/CodeSlide.js
@@ -195,7 +195,10 @@ class CodeSlide extends React.Component {
     const loc = range.loc || [];
     const slideBg = bgColor || defaultBgColor;
 
-    style.color = color || style.color;
+    const newStyle = {
+      ...style,
+      color: color || style.color,
+    };
 
     const lines = getHighlightedCodeLines(code, lang).map((line, index) => {
       return <div
@@ -213,7 +216,7 @@ class CodeSlide extends React.Component {
       <Slide ref='slide' bgColor={slideBg} margin={1} {...rest}>
         {range.title && <CodeSlideTitle>{range.title}</CodeSlideTitle>}
 
-        <pre ref="container" style={style}>
+        <pre ref="container" style={newStyle}>
           <code style={{ display: "inline-block", textAlign: "left" }}>{lines}</code>
         </pre>
 


### PR DESCRIPTION
In React 16 style prop is frozen, that's why writing color property in render fails with error.

https://github.com/facebook/react/blob/94f44aeba72eacb04443974c2c6c91a050d61b1c/packages/react-dom/src/client/ReactDOMFiberComponent.js#L262-L269

Related to https://github.com/facebook/react/issues/11520